### PR TITLE
store abi use hex encode not ethabi encode param, keep same with othe…

### DIFF
--- a/cita-tool/src/client/basic.rs
+++ b/cita-tool/src/client/basic.rs
@@ -15,7 +15,6 @@ use tokio;
 use types::U256;
 use uuid::Uuid;
 
-use crate::abi::encode_params;
 use crate::client::{remove_0x, TransactionOptions};
 use crate::crypto::PrivateKey;
 use crate::error::ToolError;
@@ -1037,7 +1036,7 @@ where
     /// Store contract ABI to chain, ABI can be get back by `getAbi` rpc call
     fn store_abi(&mut self, address: &str, content: String, quota: Option<u64>) -> Result<T, E> {
         let address = remove_0x(address);
-        let content_abi = encode_params(&["string".to_owned()], &[content], false)?;
+        let content_abi = encode(content);
         let data = format!("0x{}{}", address, content_abi);
         let tx_options = TransactionOptions::new()
             .set_code(&data)
@@ -1071,7 +1070,7 @@ where
     /// Amend contract ABI
     fn amend_abi(&mut self, address: &str, content: String, quota: Option<u64>) -> Result<T, E> {
         let address = remove_0x(address);
-        let content_abi = encode_params(&["string".to_owned()], &[content], false)?;
+        let content_abi = encode(content);
         let data = format!("0x{}{}", address, content_abi);
         let tx_options = TransactionOptions::new()
             .set_code(&data)


### PR DESCRIPTION
fix to keep same with java/js sdk.
store abi
```
cita> store abi --address 0xffffffffffffffffffffffffffffffffff020000 --content "abc" --private-key 0x...
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0x3a69272b5bd0473497747e3263c191c7e84d81b7f42694e290b43582c04efbdf",
    "status": "OK"
  }
}
```
get abi
before
```
cita> rpc getAbi --address 0xffffffffffffffffffffffffffffffffff020000
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616263000000000000000000
0000000000000000000000000000000000000000"
}
```
after this pr
```
cita> rpc getAbi --address 0xffffffffffffffffffffffffffffffffff020000
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x616263"
}
```